### PR TITLE
Update odroidc2.conf

### DIFF
--- a/conf/machine/odroidc2.conf
+++ b/conf/machine/odroidc2.conf
@@ -12,7 +12,7 @@ DVBPROVIDER = "kernel"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS = "\
     hardkernel-mali-${MACHINE} \
-    ${@bb.utils.contains('GST_VERSION', '1.0', 'gst-amlavsink1 ', 'gst-amlavsink gst-amlavout  gst-ffmpeg gst-fluendo-mpegdemux ', d)} \
+    ${@bb.utils.contains('GST_VERSION', '1.0', 'gst-amlavsink ', 'gst-amlavsink gst-amlavout  gst-ffmpeg gst-fluendo-mpegdemux ', d)} \
     \
      \
     opengl-amlogic \


### PR DESCRIPTION
To avoid this failure. Thanks to starz on on PLI forum
```
NOTE: Resolving any missing task queue dependencies
ERROR: Nothing RPROVIDES 'gst-amlavsink1' (but /home/openvix/openpli-oe-core/openembedded-core/meta/recipes-core/packagegroups/packagegroup-core-boot.bb RDEPENDS on or otherwise requires it)
NOTE: Runtime target 'gst-amlavsink1' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['gst-amlavsink1']
NOTE: Runtime target 'packagegroup-core-boot' is unbuildable, removing...
Missing or unbuildable dependency chain was: ['packagegroup-core-boot', 'gst-amlavsink1']
ERROR: Required build target 'openpli-enigma2-image' has no buildable providers.
Missing or unbuildable dependency chain was: ['openpli-enigma2-image', 'packagegroup-core-boot', 'gst-amlavsink1']

Summary: There were 8 WARNING messages shown.
Summary: There were 2 ERROR messages shown, returning a non-zero exit code.
Makefile:125: recipe for target 'image' failed
make: *** [image] Error 1
```